### PR TITLE
hyphenate second-mate's billet as per printed copy

### DIFF
--- a/525.txt
+++ b/525.txt
@@ -402,7 +402,7 @@ humiliation of it. Remember he was sixty, and it was his first command.
 Mahon said it was a foolish business, and would end badly. I loved the
 ship more than ever, and wanted awfully to get to Bankok. To Bankok!
 Magic name, blessed name. Mesopotamia wasn't a patch on it. Remember I
-was twenty, and it was my first second mate's billet, and the East was
+was twenty, and it was my first second-mate's billet, and the East was
 waiting for me.
 
 "We went out and anchored in the outer roads with a fresh crew--the

--- a/525.txt
+++ b/525.txt
@@ -391,7 +391,7 @@ finished, cargo re-shipped; a new crew came on board, and we went
 out--for Bankok. At the end of a week we were back again. The crew said
 they weren't going to Bankok--a hundred and fifty days' passage--in a
 something hooker that wanted pumping eight hours out of the twenty-four;
-and the nautical papers inserted again the little paragraph: _'Judea_.
+and the nautical papers inserted again the little paragraph: '_Judea_.
 Barque. Tyne to Bankok; coals; put back to Falmouth leaky and with crew
 refusing duty.'
 


### PR DESCRIPTION
Although "second mate" as a position is not hyphenated, it should be when forming a compound adjective. Anyway, the printed text properly does hyphenate it, so I'm correcting the etext to match the print version
