### PR TITLE
use true apostrophes, quotes and dashes. Mark charset as UTF-8

### DIFF
--- a/525.txt
+++ b/525.txt
@@ -15,7 +15,7 @@ Posting Date: June 18, 2009
 
 Language: English
 
-Character set encoding: ASCII
+Character set encoding: UTF-8
 
 *** START OF THIS PROJECT GUTENBERG EBOOK YOUTH ***
 
@@ -37,8 +37,8 @@ By Joseph Conrad
 
 
 
-  "... But the Dwarf answered: No; something human is dearer to me
-  than the wealth of all the world." GRIMM'S TALES.
+  “... But the Dwarf answered: No; something human is dearer to me
+  than the wealth of all the world.” GRIMM’S TALES.
 
 
 
@@ -51,7 +51,7 @@ YOUTH
 
 
 This could have occurred nowhere but in England, where men and sea
-interpenetrate, so to speak--the sea entering into the life of most men,
+interpenetrate, so to speak—the sea entering into the life of most men,
 and the men knowing something or everything about the sea, in the way of
 amusement, of travel, or of bread-winning.
 
@@ -59,11 +59,11 @@ We were sitting round a mahogany table that reflected the bottle, the
 claret-glasses, and our faces as we leaned on our elbows. There was a
 director of companies, an accountant, a lawyer, Marlow, and myself. The
 director had been a _Conway_ boy, the accountant had served four years at
-sea, the lawyer--a fine crusted Tory, High Churchman, the best of old
-fellows, the soul of honour--had been chief officer in the P. & O.
+sea, the lawyer—a fine crusted Tory, High Churchman, the best of old
+fellows, the soul of honour—had been chief officer in the P. & O.
 service in the good old days when mail-boats were square-rigged at least
 on two masts, and used to come down the China Sea before a fair monsoon
-with stun'-sails set alow and aloft. We all began life in the merchant
+with stun’-sails set alow and aloft. We all began life in the merchant
 service. Between the five of us there was the strong bond of the sea,
 and also the fellowship of the craft, which no amount of enthusiasm for
 yachting, cruising, and so on can give, since one is only the amusement
@@ -72,83 +72,83 @@ of life and the other is life itself.
 Marlow (at least I think that is how he spelt his name) told the story,
 or rather the chronicle, of a voyage:
 
-"Yes, I have seen a little of the Eastern seas; but what I remember best
+“Yes, I have seen a little of the Eastern seas; but what I remember best
 is my first voyage there. You fellows know there are those voyages that
 seem ordered for the illustration of life, that might stand for a symbol
 of existence. You fight, work, sweat, nearly kill yourself, sometimes do
-kill yourself, trying to accomplish something--and you can't. Not
+kill yourself, trying to accomplish something—and you can’t. Not
 from any fault of yours. You simply can do nothing, neither great nor
-little--not a thing in the world--not even marry an old maid, or get a
+little—not a thing in the world—not even marry an old maid, or get a
 wretched 600-ton cargo of coal to its port of destination.
 
-"It was altogether a memorable affair. It was my first voyage to the
-East, and my first voyage as second mate; it was also my skipper's first
-command. You'll admit it was time. He was sixty if a day; a little man,
+“It was altogether a memorable affair. It was my first voyage to the
+East, and my first voyage as second mate; it was also my skipper’s first
+command. You’ll admit it was time. He was sixty if a day; a little man,
 with a broad, not very straight back, with bowed shoulders and one leg
 more bandy than the other, he had that queer twisted-about appearance
 you see so often in men who work in the fields. He had a nut-cracker
-face--chin and nose trying to come together over a sunken mouth--and it
+face—chin and nose trying to come together over a sunken mouth—and it
 was framed in iron-grey fluffy hair, that looked like a chin strap of
 cotton-wool sprinkled with coal-dust. And he had blue eyes in that
-old face of his, which were amazingly like a boy's, with that candid
+old face of his, which were amazingly like a boy’s, with that candid
 expression some quite common men preserve to the end of their days by
 a rare internal gift of simplicity of heart and rectitude of soul.
 What induced him to accept me was a wonder. I had come out of a crack
 Australian clipper, where I had been third officer, and he seemed to
 have a prejudice against crack clippers as aristocratic and high-toned.
-He said to me, 'You know, in this ship you will have to work.' I said
-I had to work in every ship I had ever been in. 'Ah, but this is
+He said to me, ‘You know, in this ship you will have to work.’ I said
+I had to work in every ship I had ever been in. ‘Ah, but this is
 different, and you gentlemen out of them big ships;... but there! I
-dare say you will do. Join to-morrow.'
+dare say you will do. Join to-morrow.’
 
-"I joined to-morrow. It was twenty-two years ago; and I was just twenty.
+“I joined to-morrow. It was twenty-two years ago; and I was just twenty.
 How time passes! It was one of the happiest days of my life. Fancy!
-Second mate for the first time--a really responsible officer! I wouldn't
+Second mate for the first time—a really responsible officer! I wouldn’t
 have thrown up my new billet for a fortune. The mate looked me over
 carefully. He was also an old chap, but of another stamp. He had a Roman
 nose, a snow-white, long beard, and his name was Mahon, but he insisted
 that it should be pronounced Mann. He was well connected; yet there was
 something wrong with his luck, and he had never got on.
 
-"As to the captain, he had been for years in coasters, then in the
+“As to the captain, he had been for years in coasters, then in the
 Mediterranean, and last in the West Indian trade. He had never been
-round the Capes. He could just write a kind of sketchy hand, and didn't
+round the Capes. He could just write a kind of sketchy hand, and didn’t
 care for writing at all. Both were thorough good seamen of course,
 and between those two old chaps I felt like a small boy between two
 grandfathers.
 
-"The ship also was old. Her name was the _Judea_. Queer name, isn't it?
-She belonged to a man Wilmer, Wilcox--some name like that; but he has
-been bankrupt and dead these twenty years or more, and his name don't
+“The ship also was old. Her name was the _Judea_. Queer name, isn’t it?
+She belonged to a man Wilmer, Wilcox—some name like that; but he has
+been bankrupt and dead these twenty years or more, and his name don’t
 matter. She had been laid up in Shadwell basin for ever so long. You may
-imagine her state. She was all rust, dust, grime--soot aloft, dirt on
+imagine her state. She was all rust, dust, grime—soot aloft, dirt on
 deck. To me it was like coming out of a palace into a ruined cottage.
 She was about 400 tons, had a primitive windlass, wooden latches to the
 doors, not a bit of brass about her, and a big square stern. There was
 on it, below her name in big letters, a lot of scroll work, with the
-gilt off, and some sort of a coat of arms, with the motto 'Do or Die'
+gilt off, and some sort of a coat of arms, with the motto ‘Do or Die’
 underneath. I remember it took my fancy immensely. There was a touch of
-romance in it, something that made me love the old thing--something that
+romance in it, something that made me love the old thing—something that
 appealed to my youth!
 
-"We left London in ballast--sand ballast--to load a cargo of coal in a
+“We left London in ballast—sand ballast—to load a cargo of coal in a
 northern port for Bankok. Bankok! I thrilled. I had been six years at
 sea, but had only seen Melbourne and Sydney, very good places, charming
-places in their way--but Bankok!
+places in their way—but Bankok!
 
-"We worked out of the Thames under canvas, with a North Sea pilot on
+“We worked out of the Thames under canvas, with a North Sea pilot on
 board. His name was Jermyn, and he dodged all day long about the galley
 drying his handkerchief before the stove. Apparently he never slept.
 He was a dismal man, with a perpetual tear sparkling at the end of his
 nose, who either had been in trouble, or was in trouble, or expected
-to be in trouble--couldn't be happy unless something went wrong. He
+to be in trouble—couldn’t be happy unless something went wrong. He
 mistrusted my youth, my common-sense, and my seamanship, and made a
 point of showing it in a hundred little ways. I dare say he was right.
 It seems to me I knew very little then, and I know not much more now;
 but I cherish a hate for that Jermyn to this day.
 
-"We were a week working up as far as Yarmouth Roads, and then we got
-into a gale--the famous October gale of twenty-two years ago. It was
+“We were a week working up as far as Yarmouth Roads, and then we got
+into a gale—the famous October gale of twenty-two years ago. It was
 wind, lightning, sleet, snow, and a terrific sea. We were flying light,
 and you may imagine how bad it was when I tell you we had smashed
 bulwarks and a flooded deck. On the second night she shifted her ballast
@@ -158,41 +158,41 @@ try to right her, and there we were in that vast hold, gloomy like a
 cavern, the tallow dips stuck and flickering on the beams, the gale
 howling above, the ship tossing about like mad on her side; there we
 all were, Jermyn, the captain, everyone, hardly able to keep our feet,
-engaged on that gravedigger's work, and trying to toss shovelfuls of wet
+engaged on that gravedigger’s work, and trying to toss shovelfuls of wet
 sand up to windward. At every tumble of the ship you could see vaguely
 in the dim light men falling down with a great flourish of shovels.
-One of the ship's boys (we had two), impressed by the weirdness of the
+One of the ship’s boys (we had two), impressed by the weirdness of the
 scene, wept as if his heart would break. We could hear him blubbering
 somewhere in the shadows.
 
-"On the third day the gale died out, and by-and-by a north-country tug
+“On the third day the gale died out, and by-and-by a north-country tug
 picked us up. We took sixteen days in all to get from London to the
 Tyne! When we got into dock we had lost our turn for loading, and they
 hauled us off to a tier where we remained for a month. Mrs. Beard (the
-captain's name was Beard) came from Colchester to see the old man. She
+captain’s name was Beard) came from Colchester to see the old man. She
 lived on board. The crew of runners had left, and there remained only
 the officers, one boy, and the steward, a mulatto who answered to the
 name of Abraham. Mrs. Beard was an old woman, with a face all wrinkled
 and ruddy like a winter apple, and the figure of a young girl. She
 caught sight of me once, sewing on a button, and insisted on having my
-shirts to repair. This was something different from the captains' wives
+shirts to repair. This was something different from the captains’ wives
 I had known on board crack clippers. When I brought her the shirts, she
-said: 'And the socks? They want mending, I am sure, and John's--Captain
-Beard's--things are all in order now. I would be glad of something to
-do.' Bless the old woman! She overhauled my outfit for me, and meantime
-I read for the first time _Sartor Resartus_ and Burnaby's _Ride to
-Khiva_. I didn't understand much of the first then; but I remember I
+said: ‘And the socks? They want mending, I am sure, and John’s—Captain
+Beard’s—things are all in order now. I would be glad of something to
+do.’ Bless the old woman! She overhauled my outfit for me, and meantime
+I read for the first time _Sartor Resartus_ and Burnaby’s _Ride to
+Khiva_. I didn’t understand much of the first then; but I remember I
 preferred the soldier to the philosopher at the time; a preference
 which life has only confirmed. One was a man, and the other was either
-more--or less. However, they are both dead, and Mrs. Beard is dead, and
-youth, strength, genius, thoughts, achievements, simple hearts--all dies
+more—or less. However, they are both dead, and Mrs. Beard is dead, and
+youth, strength, genius, thoughts, achievements, simple hearts—all dies
 .... No matter.
 
-"They loaded us at last. We shipped a crew. Eight able seamen and two
+“They loaded us at last. We shipped a crew. Eight able seamen and two
 boys. We hauled off one evening to the buoys at the dock-gates, ready to
 go out, and with a fair prospect of beginning the voyage next day. Mrs.
 Beard was to start for home by a late train. When the ship was fast
-we went to tea. We sat rather silent through the meal--Mahon, the old
+we went to tea. We sat rather silent through the meal—Mahon, the old
 couple, and I. I finished first, and slipped away for a smoke, my cabin
 being in a deck-house just against the poop. It was high water, blowing
 fresh with a drizzle; the double dock-gates were opened, and the steam
@@ -202,67 +202,67 @@ of hailing on the pier-heads. I watched the procession of head-lights
 gliding high and of green lights gliding low in the night, when suddenly
 a red gleam flashed at me, vanished, came into view again, and remained.
 The fore-end of a steamer loomed up close. I shouted down the cabin,
-'Come up, quick!' and then heard a startled voice saying afar in the
-dark, 'Stop her, sir.' A bell jingled. Another voice cried warningly,
-'We are going right into that barque, sir.' The answer to this was a
-gruff 'All right,' and the next thing was a heavy crash as the steamer
+‘Come up, quick!’ and then heard a startled voice saying afar in the
+dark, ‘Stop her, sir.’ A bell jingled. Another voice cried warningly,
+‘We are going right into that barque, sir.’ The answer to this was a
+gruff ‘All right,’ and the next thing was a heavy crash as the steamer
 struck a glancing blow with the bluff of her bow about our fore-rigging.
 There was a moment of confusion, yelling, and running about. Steam
-roared. Then somebody was heard saying, 'All clear, sir.'... 'Are
-you all right?' asked the gruff voice. I had jumped forward to see the
-damage, and hailed back, 'I think so.' 'Easy astern,' said the gruff
-voice. A bell jingled. 'What steamer is that?' screamed Mahon. By that
+roared. Then somebody was heard saying, ‘All clear, sir.’... ‘Are
+you all right?’ asked the gruff voice. I had jumped forward to see the
+damage, and hailed back, ‘I think so.’ ‘Easy astern,’ said the gruff
+voice. A bell jingled. ‘What steamer is that?’ screamed Mahon. By that
 time she was no more to us than a bulky shadow maneuvering a little
-way off. They shouted at us some name--a woman's name, Miranda or
-Melissa--or some such thing. 'This means another month in this beastly
-hole,' said Mahon to me, as we peered with lamps about the splintered
-bulwarks and broken braces. 'But where's the captain?'
+way off. They shouted at us some name—a woman’s name, Miranda or
+Melissa—or some such thing. ‘This means another month in this beastly
+hole,’ said Mahon to me, as we peered with lamps about the splintered
+bulwarks and broken braces. ‘But where’s the captain?’
 
-"We had not heard or seen anything of him all that time. We went aft to
+“We had not heard or seen anything of him all that time. We went aft to
 look. A doleful voice arose hailing somewhere in the middle of the dock,
-'_Judea_ ahoy!'... How the devil did he get there?... 'Hallo!' we
-shouted. 'I am adrift in our boat without oars,' he cried. A belated
+‘_Judea_ ahoy!’... How the devil did he get there?... ‘Hallo!’ we
+shouted. ‘I am adrift in our boat without oars,’ he cried. A belated
 waterman offered his services, and Mahon struck a bargain with him for
 half-a-crown to tow our skipper alongside; but it was Mrs. Beard that
 came up the ladder first. They had been floating about the dock in that
 mizzly cold rain for nearly an hour. I was never so surprised in my
 life.
 
-"It appears that when he heard my shout 'Come up,' he understood at once
+“It appears that when he heard my shout ‘Come up,’ he understood at once
 what was the matter, caught up his wife, ran on deck, and across,
 and down into our boat, which was fast to the ladder. Not bad for a
 sixty-year-old. Just imagine that old fellow saving heroically in his
-arms that old woman--the woman of his life. He set her down on a thwart,
+arms that old woman—the woman of his life. He set her down on a thwart,
 and was ready to climb back on board when the painter came adrift
 somehow, and away they went together. Of course in the confusion we
-did not hear him shouting. He looked abashed. She said cheerfully, 'I
-suppose it does not matter my losing the train now?' 'No, Jenny--you go
-below and get warm,' he growled. Then to us: 'A sailor has no business
-with a wife--I say. There I was, out of the ship. Well, no harm done
-this time. Let's go and look at what that fool of a steamer smashed.'
+did not hear him shouting. He looked abashed. She said cheerfully, ‘I
+suppose it does not matter my losing the train now?’ ‘No, Jenny—you go
+below and get warm,’ he growled. Then to us: ‘A sailor has no business
+with a wife—I say. There I was, out of the ship. Well, no harm done
+this time. Let’s go and look at what that fool of a steamer smashed.’
 
-"It wasn't much, but it delayed us three weeks. At the end of that time,
-the captain being engaged with his agents, I carried Mrs. Beard's bag to
+“It wasn’t much, but it delayed us three weeks. At the end of that time,
+the captain being engaged with his agents, I carried Mrs. Beard’s bag to
 the railway-station and put her all comfy into a third-class carriage.
-She lowered the window to say, 'You are a good young man. If you see
-John--Captain Beard--without his muffler at night, just remind him from
-me to keep his throat well wrapped up.' 'Certainly, Mrs. Beard,' I said.
-'You are a good young man; I noticed how attentive you are to John--to
-Captain--' The train pulled out suddenly; I took my cap off to the old
+She lowered the window to say, ‘You are a good young man. If you see
+John—Captain Beard—without his muffler at night, just remind him from
+me to keep his throat well wrapped up.’ ‘Certainly, Mrs. Beard,’ I said.
+‘You are a good young man; I noticed how attentive you are to John—to
+Captain—’ The train pulled out suddenly; I took my cap off to the old
 woman: I never saw her again... Pass the bottle.
 
-"We went to sea next day. When we made that start for Bankok we had been
+“We went to sea next day. When we made that start for Bankok we had been
 already three months out of London. We had expected to be a fortnight or
-so--at the outside.
+so—at the outside.
 
-"It was January, and the weather was beautiful--the beautiful sunny
+“It was January, and the weather was beautiful—the beautiful sunny
 winter weather that has more charm than in the summer-time, because it
-is unexpected, and crisp, and you know it won't, it can't, last long.
-It's like a windfall, like a godsend, like an unexpected piece of luck.
+is unexpected, and crisp, and you know it won’t, it can’t, last long.
+It’s like a windfall, like a godsend, like an unexpected piece of luck.
 
-"It lasted all down the North Sea, all down Channel; and it lasted till
+“It lasted all down the North Sea, all down Channel; and it lasted till
 we were three hundred miles or so to the westward of the Lizards: then
-the wind went round to the sou'west and began to pipe up. In two days it
+the wind went round to the sou’west and began to pipe up. In two days it
 blew a gale. The _Judea_, hove to, wallowed on the Atlantic like an old
 candlebox. It blew day after day: it blew with spite, without interval,
 without mercy, without rest. The world was nothing but an immensity of
@@ -276,21 +276,21 @@ she stood on her head, she sat on her tail, she rolled, she groaned, and
 we had to hold on while on deck and cling to our bunks when below, in a
 constant effort of body and worry of mind.
 
-"One night Mahon spoke through the small window of my berth. It opened
+“One night Mahon spoke through the small window of my berth. It opened
 right into my very bed, and I was lying there sleepless, in my boots,
 feeling as though I had not slept for years, and could not if I tried.
-He said excitedly--
+He said excitedly—
 
-"'You got the sounding-rod in here, Marlow? I can't get the pumps to
-suck. By God! it's no child's play.'
+“‘You got the sounding-rod in here, Marlow? I can’t get the pumps to
+suck. By God! it’s no child’s play.’
 
-"I gave him the sounding-rod and lay down again, trying to think of
-various things--but I thought only of the pumps. When I came on deck
+“I gave him the sounding-rod and lay down again, trying to think of
+various things—but I thought only of the pumps. When I came on deck
 they were still at it, and my watch relieved at the pumps. By the light
 of the lantern brought on deck to examine the sounding-rod I caught a
 glimpse of their weary, serious faces. We pumped all the four hours.
-We pumped all night, all day, all the week,--watch and watch. She was
-working herself loose, and leaked badly--not enough to drown us at once,
+We pumped all night, all day, all the week,—watch and watch. She was
+working herself loose, and leaked badly—not enough to drown us at once,
 but enough to kill us with the work at the pumps. And while we pumped
 the ship was going from us piecemeal: the bulwarks went, the stanchions
 were torn out, the ventilators smashed, the cabin-door burst in. There
@@ -300,9 +300,9 @@ gripes. I had lashed her myself, and was rather proud of my handiwork,
 which had withstood so long the malice of the sea. And we pumped. And
 there was no break in the weather. The sea was white like a sheet of
 foam, like a caldron of boiling milk; there was not a break in the
-clouds, no--not the size of a man's hand--no, not for so much as ten
+clouds, no—not the size of a man’s hand—no, not for so much as ten
 seconds. There was for us no sky, there were for us no stars, no sun,
-no universe--nothing but angry clouds and an infuriated sea. We pumped
+no universe—nothing but angry clouds and an infuriated sea. We pumped
 watch and watch, for dear life; and it seemed to last for months, for
 years, for all eternity, as though we had been dead and gone to a hell
 for sailors. We forgot the day of the week, the name of the month, what
@@ -314,50 +314,50 @@ with a rope about the men, the pumps, and the mainmast, and we turned,
 we turned incessantly, with the water to our waists, to our necks, over
 our heads. It was all one. We had forgotten how it felt to be dry.
 
-"And there was somewhere in me the thought: By Jove! this is the deuce
-of an adventure--something you read about; and it is my first voyage as
-second mate--and I am only twenty--and here I am lasting it out as well
+“And there was somewhere in me the thought: By Jove! this is the deuce
+of an adventure—something you read about; and it is my first voyage as
+second mate—and I am only twenty—and here I am lasting it out as well
 as any of these men, and keeping my chaps up to the mark. I was pleased.
 I would not have given up the experience for worlds. I had moments of
 exultation. Whenever the old dismantled craft pitched heavily with her
 counter high in the air, she seemed to me to throw up, like an appeal,
 like a defiance, like a cry to the clouds without mercy, the words
-written on her stern: '_Judea_, London. Do or Die.'
+written on her stern: ‘_Judea_, London. Do or Die.’
 
-"O youth! The strength of it, the faith of it, the imagination of it! To
+“O youth! The strength of it, the faith of it, the imagination of it! To
 me she was not an old rattle-trap carting about the world a lot of coal
-for a freight--to me she was the endeavour, the test, the trial of life.
-I think of her with pleasure, with affection, with regret--as you would
+for a freight—to me she was the endeavour, the test, the trial of life.
+I think of her with pleasure, with affection, with regret—as you would
 think of someone dead you have loved. I shall never forget her....
 Pass the bottle.
 
-"One night when tied to the mast, as I explained, we were pumping
+“One night when tied to the mast, as I explained, we were pumping
 on, deafened with the wind, and without spirit enough in us to wish
 ourselves dead, a heavy sea crashed aboard and swept clean over us. As
-soon as I got my breath I shouted, as in duty bound, 'Keep on, boys!'
+soon as I got my breath I shouted, as in duty bound, ‘Keep on, boys!’
 when suddenly I felt something hard floating on deck strike the calf of
 my leg. I made a grab at it and missed. It was so dark we could not see
-each other's faces within a foot--you understand.
+each other’s faces within a foot—you understand.
 
-"After that thump the ship kept quiet for a while, and the thing,
-whatever it was, struck my leg again. This time I caught it--and it was
+“After that thump the ship kept quiet for a while, and the thing,
+whatever it was, struck my leg again. This time I caught it—and it was
 a saucepan. At first, being stupid with fatigue and thinking of nothing
 but the pumps, I did not understand what I had in my hand. Suddenly it
-dawned upon me, and I shouted, 'Boys, the house on deck is gone. Leave
-this, and let's look for the cook.'
+dawned upon me, and I shouted, ‘Boys, the house on deck is gone. Leave
+this, and let’s look for the cook.’
 
-"There was a deck-house forward, which contained the galley, the cook's
+“There was a deck-house forward, which contained the galley, the cook’s
 berth, and the quarters of the crew. As we had expected for days to see
-it swept away, the hands had been ordered to sleep in the cabin--the
+it swept away, the hands had been ordered to sleep in the cabin—the
 only safe place in the ship. The steward, Abraham, however, persisted
-in clinging to his berth, stupidly, like a mule--from sheer fright
-I believe, like an animal that won't leave a stable falling in an
+in clinging to his berth, stupidly, like a mule—from sheer fright
+I believe, like an animal that won’t leave a stable falling in an
 earthquake. So we went to look for him. It was chancing death, since
 once out of our lashings we were as exposed as if on a raft. But we
 went. The house was shattered as if a shell had exploded inside. Most
-of it had gone overboard--stove, men's quarters, and their property,
+of it had gone overboard—stove, men’s quarters, and their property,
 all was gone; but two posts, holding a portion of the bulkhead to which
-Abraham's bunk was attached, remained as if by a miracle. We groped in
+Abraham’s bunk was attached, remained as if by a miracle. We groped in
 the ruins and came upon this, and there he was, sitting in his bunk,
 surrounded by foam and wreckage, jabbering cheerfully to himself. He
 was out of his mind; completely and for ever mad, with this sudden shock
@@ -368,80 +368,80 @@ to see how he got on. Those below would pick him up at the bottom of
 the stairs all right. We were in a hurry to go back to the pumps. That
 business could not wait. A bad leak is an inhuman thing.
 
-"One would think that the sole purpose of that fiendish gale had been to
+“One would think that the sole purpose of that fiendish gale had been to
 make a lunatic of that poor devil of a mulatto. It eased before morning,
 and next day the sky cleared, and as the sea went down the leak took up.
 When it came to bending a fresh set of sails the crew demanded to put
-back--and really there was nothing else to do. Boats gone, decks swept
+back—and really there was nothing else to do. Boats gone, decks swept
 clean, cabin gutted, men without a stitch but what they stood in, stores
-spoiled, ship strained. We put her head for home, and--would you believe
+spoiled, ship strained. We put her head for home, and—would you believe
 it? The wind came east right in our teeth. It blew fresh, it blew
 continuously. We had to beat up every inch of the way, but she did
-not leak so badly, the water keeping comparatively smooth. Two hours'
-pumping in every four is no joke--but it kept her afloat as far as
+not leak so badly, the water keeping comparatively smooth. Two hours’
+pumping in every four is no joke—but it kept her afloat as far as
 Falmouth.
 
-"The good people there live on casualties of the sea, and no doubt were
+“The good people there live on casualties of the sea, and no doubt were
 glad to see us. A hungry crowd of shipwrights sharpened their chisels
 at the sight of that carcass of a ship. And, by Jove! they had pretty
 pickings off us before they were done. I fancy the owner was already in
 a tight place. There were delays. Then it was decided to take part
 of the cargo out and calk her topsides. This was done, the repairs
 finished, cargo re-shipped; a new crew came on board, and we went
-out--for Bankok. At the end of a week we were back again. The crew said
-they weren't going to Bankok--a hundred and fifty days' passage--in a
+out—for Bankok. At the end of a week we were back again. The crew said
+they weren’t going to Bankok—a hundred and fifty days’ passage—in a
 something hooker that wanted pumping eight hours out of the twenty-four;
-and the nautical papers inserted again the little paragraph: '_Judea_.
+and the nautical papers inserted again the little paragraph: ‘_Judea_.
 Barque. Tyne to Bankok; coals; put back to Falmouth leaky and with crew
-refusing duty.'
+refusing duty.’
 
-"There were more delays--more tinkering. The owner came down for a day,
+“There were more delays—more tinkering. The owner came down for a day,
 and said she was as right as a little fiddle. Poor old Captain Beard
-looked like the ghost of a Geordie skipper--through the worry and
+looked like the ghost of a Geordie skipper—through the worry and
 humiliation of it. Remember he was sixty, and it was his first command.
 Mahon said it was a foolish business, and would end badly. I loved the
 ship more than ever, and wanted awfully to get to Bankok. To Bankok!
-Magic name, blessed name. Mesopotamia wasn't a patch on it. Remember I
-was twenty, and it was my first second-mate's billet, and the East was
+Magic name, blessed name. Mesopotamia wasn’t a patch on it. Remember I
+was twenty, and it was my first second-mate’s billet, and the East was
 waiting for me.
 
-"We went out and anchored in the outer roads with a fresh crew--the
+“We went out and anchored in the outer roads with a fresh crew—the
 third. She leaked worse than ever. It was as if those confounded
 shipwrights had actually made a hole in her. This time we did not even
 go outside. The crew simply refused to man the windlass.
 
-"They towed us back to the inner harbour, and we became a fixture, a
+“They towed us back to the inner harbour, and we became a fixture, a
 feature, an institution of the place. People pointed us out to visitors
-as 'That 'ere bark that's going to Bankok--has been here six months--put
-back three times.' On holidays the small boys pulling about in boats
-would hail, '_Judea_, ahoy!' and if a head showed above the rail
-shouted, 'Where you bound to?--Bankok?' and jeered. We were only three
+as ‘That ’ere bark that’s going to Bankok—has been here six months—put
+back three times.’ On holidays the small boys pulling about in boats
+would hail, ‘_Judea_, ahoy!’ and if a head showed above the rail
+shouted, ‘Where you bound to?—Bankok?’ and jeered. We were only three
 on board. The poor old skipper mooned in the cabin. Mahon undertook
-the cooking, and unexpectedly developed all a Frenchman's genius for
+the cooking, and unexpectedly developed all a Frenchman’s genius for
 preparing nice little messes. I looked languidly after the rigging. We
-became citizens of Falmouth. Every shopkeeper knew us. At the barber's
-or tobacconist's they asked familiarly, 'Do you think you will ever get
-to Bankok?' Meantime the owner, the underwriters, and the charterers
+became citizens of Falmouth. Every shopkeeper knew us. At the barber’s
+or tobacconist’s they asked familiarly, ‘Do you think you will ever get
+to Bankok?’ Meantime the owner, the underwriters, and the charterers
 squabbled amongst themselves in London, and our pay went on.... Pass
 the bottle.
 
-"It was horrid. Morally it was worse than pumping for life. It seemed as
+“It was horrid. Morally it was worse than pumping for life. It seemed as
 though we had been forgotten by the world, belonged to nobody, would get
 nowhere; it seemed that, as if bewitched, we would have to live for ever
 and ever in that inner harbour, a derision and a by-word to generations
-of long-shore loafers and dishonest boatmen. I obtained three months'
-pay and a five days' leave, and made a rush for London. It took me a day
-to get there and pretty well another to come back--but three months'
-pay went all the same. I don't know what I did with it. I went to a
+of long-shore loafers and dishonest boatmen. I obtained three months’
+pay and a five days’ leave, and made a rush for London. It took me a day
+to get there and pretty well another to come back—but three months’
+pay went all the same. I don’t know what I did with it. I went to a
 music-hall, I believe, lunched, dined, and supped in a swell place in
 Regent Street, and was back to time, with nothing but a complete set of
-Byron's works and a new railway rug to show for three months' work. The
-boatman who pulled me off to the ship said: 'Hallo! I thought you had
-left the old thing. _She_ will never get to Bankok.' 'That's all _you_
-know about it,' I said scornfully--but I didn't like that prophecy at
+Byron’s works and a new railway rug to show for three months’ work. The
+boatman who pulled me off to the ship said: ‘Hallo! I thought you had
+left the old thing. _She_ will never get to Bankok.’ ‘That’s all _you_
+know about it,’ I said scornfully—but I didn’t like that prophecy at
 all.
 
-"Suddenly a man, some kind of agent to somebody, appeared with full
+“Suddenly a man, some kind of agent to somebody, appeared with full
 powers. He had grog-blossoms all over his face, an indomitable energy,
 and was a jolly soul. We leaped into life again. A hulk came alongside,
 took our cargo, and then we went into dry dock to get our copper
@@ -450,42 +450,42 @@ endurance by the gale, had, as if in disgust, spat out all the oakum of
 her lower seams. She was recalked, new coppered, and made as tight as a
 bottle. We went back to the hulk and re-shipped our cargo.
 
-"Then on a fine moonlight night, all the rats left the ship.
+“Then on a fine moonlight night, all the rats left the ship.
 
-"We had been infested with them. They had destroyed our sails, consumed
+“We had been infested with them. They had destroyed our sails, consumed
 more stores than the crew, affably shared our beds and our dangers, and
 now, when the ship was made seaworthy, concluded to clear out. I called
 Mahon to enjoy the spectacle. Rat after rat appeared on our rail, took
 a last look over his shoulder, and leaped with a hollow thud into the
 empty hulk. We tried to count them, but soon lost the tale. Mahon said:
-'Well, well! don't talk to me about the intelligence of rats. They ought
+‘Well, well! don’t talk to me about the intelligence of rats. They ought
 to have left before, when we had that narrow squeak from foundering.
 There you have the proof how silly is the superstition about them. They
 leave a good ship for an old rotten hulk, where there is nothing to eat,
-too, the fools!... I don't believe they know what is safe or what is
-good for them, any more than you or I.'
+too, the fools!... I don’t believe they know what is safe or what is
+good for them, any more than you or I.’
 
-"And after some more talk we agreed that the wisdom of rats had been
+“And after some more talk we agreed that the wisdom of rats had been
 grossly overrated, being in fact no greater than that of men.
 
-"The story of the ship was known, by this, all up the Channel from
-Land's End to the Forelands, and we could get no crew on the south
+“The story of the ship was known, by this, all up the Channel from
+Land’s End to the Forelands, and we could get no crew on the south
 coast. They sent us one all complete from Liverpool, and we left once
-more--for Bankok.
+more—for Bankok.
 
-"We had fair breezes, smooth water right into the tropics, and the
+“We had fair breezes, smooth water right into the tropics, and the
 old Judea lumbered along in the sunshine. When she went eight knots
 everything cracked aloft, and we tied our caps to our heads; but mostly
 she strolled on at the rate of three miles an hour. What could you
-expect? She was tired--that old ship. Her youth was where mine is--where
-yours is--you fellows who listen to this yarn; and what friend would
-throw your years and your weariness in your face? We didn't grumble at
+expect? She was tired—that old ship. Her youth was where mine is—where
+yours is—you fellows who listen to this yarn; and what friend would
+throw your years and your weariness in your face? We didn’t grumble at
 her. To us aft, at least, it seemed as though we had been born in her,
 reared in her, had lived in her for ages, had never known any other
 ship. I would just as soon have abused the old village church at home
 for not being a cathedral.
 
-"And for me there was also my youth to make me patient. There was all
+“And for me there was also my youth to make me patient. There was all
 the East before me, and all life, and the thought that I had been tried
 in that ship and had come out pretty well. And I thought of men of old
 who, centuries ago, went that road in ships that sailed no better, to
@@ -495,48 +495,48 @@ Solomon the Jew. The old bark lumbered on, heavy with her age and the
 burden of her cargo, while I lived the life of youth in ignorance and
 hope. She lumbered on through an interminable procession of days; and
 the fresh gilding flashed back at the setting sun, seemed to cry out
-over the darkening sea the words painted on her stern, '_Judea_, London.
-Do or Die.'
+over the darkening sea the words painted on her stern, ‘_Judea_, London.
+Do or Die.’
 
-"Then we entered the Indian Ocean and steered northerly for Java Head.
+“Then we entered the Indian Ocean and steered northerly for Java Head.
 The winds were light. Weeks slipped by. She crawled on, do or die, and
 people at home began to think of posting us as overdue.
 
-"One Saturday evening, I being off duty, the men asked me to give them
-an extra bucket of water or so--for washing clothes. As I did not wish
+“One Saturday evening, I being off duty, the men asked me to give them
+an extra bucket of water or so—for washing clothes. As I did not wish
 to screw on the fresh-water pump so late, I went forward whistling, and
 with a key in my hand to unlock the forepeak scuttle, intending to serve
 the water out of a spare tank we kept there.
 
-"The smell down below was as unexpected as it was frightful. One would
+“The smell down below was as unexpected as it was frightful. One would
 have thought hundreds of paraffin-lamps had been flaring and smoking in
 that hole for days. I was glad to get out. The man with me coughed and
-said, 'Funny smell, sir.' I answered negligently, 'It's good for the
-health, they say,' and walked aft.
+said, ‘Funny smell, sir.’ I answered negligently, ‘It’s good for the
+health, they say,’ and walked aft.
 
-"The first thing I did was to put my head down the square of the midship
+“The first thing I did was to put my head down the square of the midship
 ventilator. As I lifted the lid a visible breath, something like a thin
 fog, a puff of faint haze, rose from the opening. The ascending air was
 hot, and had a heavy, sooty, paraffiny smell. I gave one sniff, and
 put down the lid gently. It was no use choking myself. The cargo was on
 fire.
 
-"Next day she began to smoke in earnest. You see it was to be expected,
+“Next day she began to smoke in earnest. You see it was to be expected,
 for though the coal was of a safe kind, that cargo had been so handled,
 so broken up with handling, that it looked more like smithy coal than
-anything else. Then it had been wetted--more than once. It rained all
+anything else. Then it had been wetted—more than once. It rained all
 the time we were taking it back from the hulk, and now with this
 long passage it got heated, and there was another case of spontaneous
 combustion.
 
-"The captain called us into the cabin. He had a chart spread on the
-table, and looked unhappy. He said, 'The coast of West Australia is
+“The captain called us into the cabin. He had a chart spread on the
+table, and looked unhappy. He said, ‘The coast of West Australia is
 near, but I mean to proceed to our destination. It is the hurricane
 month too; but we will just keep her head for Bankok, and fight the
 fire. No more putting back anywhere, if we all get roasted. We will try
-first to stifle this 'ere damned combustion by want of air.'
+first to stifle this ’ere damned combustion by want of air.’
 
-"We tried. We battened down everything, and still she smoked. The smoke
+“We tried. We battened down everything, and still she smoked. The smoke
 kept coming out through imperceptible crevices; it forced itself through
 bulkheads and covers; it oozed here and there and everywhere in slender
 threads, in an invisible film, in an incomprehensible manner. It made
@@ -545,14 +545,14 @@ places on the deck, it could be sniffed as high as the main-yard. It
 was clear that if the smoke came out the air came in. This was
 disheartening. This combustion refused to be stifled.
 
-"We resolved to try water, and took the hatches off. Enormous volumes
+“We resolved to try water, and took the hatches off. Enormous volumes
 of smoke, whitish, yellowish, thick, greasy, misty, choking, ascended as
 high as the trucks. All hands cleared out aft. Then the poisonous cloud
 blew away, and we went back to work in a smoke that was no thicker now
 than that of an ordinary factory chimney.
 
-"We rigged the force pump, got the hose along, and by-and-by it burst.
-Well, it was as old as the ship--a prehistoric hose, and past repair.
+“We rigged the force pump, got the hose along, and by-and-by it burst.
+Well, it was as old as the ship—a prehistoric hose, and past repair.
 Then we pumped with the feeble head-pump, drew water with buckets, and
 in this way managed in time to pour lots of Indian Ocean into the main
 hatch. The bright stream flashed in sunshine, fell into a layer of
@@ -563,34 +563,34 @@ of her, to pump into her; and after keeping water out of her to save
 ourselves from being drowned, we frantically poured water into her to
 save ourselves from being burnt.
 
-"And she crawled on, do or die, in the serene weather. The sky was a
+“And she crawled on, do or die, in the serene weather. The sky was a
 miracle of purity, a miracle of azure. The sea was polished, was blue,
 was pellucid, was sparkling like a precious stone, extending on all
-sides, all round to the horizon--as if the whole terrestrial globe had
+sides, all round to the horizon—as if the whole terrestrial globe had
 been one jewel, one colossal sapphire, a single gem fashioned into a
 planet. And on the luster of the great calm waters the _Judea_ glided
 imperceptibly, enveloped in languid and unclean vapours, in a lazy cloud
 that drifted to leeward, light and slow: a pestiferous cloud defiling
 the splendour of sea and sky.
 
-"All this time of course we saw no fire. The cargo smoldered at the
+“All this time of course we saw no fire. The cargo smoldered at the
 bottom somewhere. Once Mahon, as we were working side by side, said to
-me with a queer smile: 'Now, if she only would spring a tidy leak--like
-that time when we first left the Channel--it would put a stopper on this
-fire. Wouldn't it?' I remarked irrelevantly, 'Do you remember the rats?'
+me with a queer smile: ‘Now, if she only would spring a tidy leak—like
+that time when we first left the Channel—it would put a stopper on this
+fire. Wouldn’t it?’ I remarked irrelevantly, ‘Do you remember the rats?’
 
-"We fought the fire and sailed the ship too as carefully as though
+“We fought the fire and sailed the ship too as carefully as though
 nothing had been the matter. The steward cooked and attended on us. Of
 the other twelve men, eight worked while four rested. Everyone took
 his turn, captain included. There was equality, and if not exactly
 fraternity, then a deal of good feeling. Sometimes a man, as he dashed
-a bucketful of water down the hatchway, would yell out, 'Hurrah for
-Bankok!' and the rest laughed. But generally we were taciturn and
-serious--and thirsty. Oh! how thirsty! And we had to be careful with the
+a bucketful of water down the hatchway, would yell out, ‘Hurrah for
+Bankok!’ and the rest laughed. But generally we were taciturn and
+serious—and thirsty. Oh! how thirsty! And we had to be careful with the
 water. Strict allowance. The ship smoked, the sun blazed.... Pass the
 bottle.
 
-"We tried everything. We even made an attempt to dig down to the fire.
+“We tried everything. We even made an attempt to dig down to the fire.
 No good, of course. No man could remain more than a minute below. Mahon,
 who went first, fainted there, and the man who went to fetch him out
 did likewise. We lugged them out on deck. Then I leaped down to show
@@ -599,11 +599,11 @@ and contented themselves by fishing for me with a chain-hook tied to a
 broom-handle, I believe. I did not offer to go and fetch up my shovel,
 which was left down below.
 
-"Things began to look bad. We put the long-boat into the water. The
+“Things began to look bad. We put the long-boat into the water. The
 second boat was ready to swing out. We had also another, a fourteen-foot
 thing, on davits aft, where it was quite safe.
 
-"Then behold, the smoke suddenly decreased. We re-doubled our efforts
+“Then behold, the smoke suddenly decreased. We re-doubled our efforts
 to flood the bottom of the ship. In two days there was no smoke at all.
 Everybody was on the broad grin. This was on a Friday. On Saturday no
 work, but sailing the ship of course was done. The men washed their
@@ -618,36 +618,36 @@ ventilators, sniffing. It struck me suddenly poor Mahon was a very, very
 old chap. As to me, I was as pleased and proud as though I had helped to
 win a great naval battle. O! Youth!
 
-"The night was fine. In the morning a homeward-bound ship passed us hull
-down,--the first we had seen for months; but we were nearing the land at
+“The night was fine. In the morning a homeward-bound ship passed us hull
+down,—the first we had seen for months; but we were nearing the land at
 last, Java Head being about 190 miles off, and nearly due north.
 
-"Next day it was my watch on deck from eight to twelve. At breakfast the
-captain observed, 'It's wonderful how that smell hangs about the cabin.'
+“Next day it was my watch on deck from eight to twelve. At breakfast the
+captain observed, ‘It’s wonderful how that smell hangs about the cabin.’
 About ten, the mate being on the poop, I stepped down on the main-deck
-for a moment. The carpenter's bench stood abaft the mainmast: I leaned
+for a moment. The carpenter’s bench stood abaft the mainmast: I leaned
 against it sucking at my pipe, and the carpenter, a young chap, came to
-talk to me. He remarked, 'I think we have done very well, haven't we?'
+talk to me. He remarked, ‘I think we have done very well, haven’t we?’
 and then I perceived with annoyance the fool was trying to tilt the
-bench. I said curtly, 'Don't, Chips,' and immediately became aware of a
-queer sensation, of an absurd delusion,--I seemed somehow to be in
-the air. I heard all round me like a pent-up breath released--as if
-a thousand giants simultaneously had said Phoo!--and felt a dull
-concussion which made my ribs ache suddenly. No doubt about it--I was
+bench. I said curtly, ‘Don’t, Chips,’ and immediately became aware of a
+queer sensation, of an absurd delusion,—I seemed somehow to be in
+the air. I heard all round me like a pent-up breath released—as if
+a thousand giants simultaneously had said Phoo!—and felt a dull
+concussion which made my ribs ache suddenly. No doubt about it—I was
 in the air, and my body was describing a short parabola. But short as
 it was, I had the time to think several thoughts in, as far as I can
-remember, the following order: 'This can't be the carpenter--What is
-it?--Some accident--Submarine volcano?--Coals, gas!--By Jove! we are
-being blown up--Everybody's dead--I am falling into the after-hatch--I
-see fire in it.'
+remember, the following order: ‘This can’t be the carpenter—What is
+it?—Some accident—Submarine volcano?—Coals, gas!—By Jove! we are
+being blown up—Everybody’s dead—I am falling into the after-hatch—I
+see fire in it.’
 
-"The coal-dust suspended in the air of the hold had glowed dull-red
+“The coal-dust suspended in the air of the hold had glowed dull-red
 at the moment of the explosion. In the twinkling of an eye, in an
 infinitesimal fraction of a second since the first tilt of the bench, I
 was sprawling full length on the cargo. I picked myself up and scrambled
 out. It was quick like a rebound. The deck was a wilderness of smashed
 timber, lying crosswise like trees in a wood after a hurricane; an
-immense curtain of soiled rags waved gently before me--it was the
+immense curtain of soiled rags waved gently before me—it was the
 mainsail blown to strips. I thought, The masts will be toppling over
 directly; and to get out of the way bolted on all-fours towards the
 poop-ladder. The first person I saw was Mahon, with eyes like saucers,
@@ -660,45 +660,45 @@ I did not know that I had no hair, no eyebrows, no eyelashes, that my
 young moustache was burnt off, that my face was black, one cheek laid
 open, my nose cut, and my chin bleeding. I had lost my cap, one of my
 slippers, and my shirt was torn to rags. Of all this I was not aware. I
-was amazed to see the ship still afloat, the poop-deck whole--and, most
+was amazed to see the ship still afloat, the poop-deck whole—and, most
 of all, to see anybody alive. Also the peace of the sky and the serenity
 of the sea were distinctly surprising. I suppose I expected to see them
 convulsed with horror.... Pass the bottle.
 
-"There was a voice hailing the ship from somewhere--in the air, in the
-sky--I couldn't tell. Presently I saw the captain--and he was mad. He
-asked me eagerly, 'Where's the cabin-table?' and to hear such a question
+“There was a voice hailing the ship from somewhere—in the air, in the
+sky—I couldn’t tell. Presently I saw the captain—and he was mad. He
+asked me eagerly, ‘Where’s the cabin-table?’ and to hear such a question
 was a frightful shock. I had just been blown up, you understand, and
-vibrated with that experience,--I wasn't quite sure whether I was alive.
-Mahon began to stamp with both feet and yelled at him, 'Good God! don't
-you see the deck's blown out of her?' I found my voice, and stammered
-out as if conscious of some gross neglect of duty, 'I don't know where
-the cabin-table is.' It was like an absurd dream.
+vibrated with that experience,—I wasn’t quite sure whether I was alive.
+Mahon began to stamp with both feet and yelled at him, ‘Good God! don’t
+you see the deck’s blown out of her?’ I found my voice, and stammered
+out as if conscious of some gross neglect of duty, ‘I don’t know where
+the cabin-table is.’ It was like an absurd dream.
 
-"Do you know what he wanted next? Well, he wanted to trim the yards.
+“Do you know what he wanted next? Well, he wanted to trim the yards.
 Very placidly, and as if lost in thought, he insisted on having the
-foreyard squared. 'I don't know if there's anybody alive,' said Mahon,
-almost tearfully. 'Surely,' he said gently, 'there will be enough left
-to square the foreyard.'
+foreyard squared. ‘I don’t know if there’s anybody alive,’ said Mahon,
+almost tearfully. ‘Surely,’ he said gently, ‘there will be enough left
+to square the foreyard.’
 
-"The old chap, it seems, was in his own berth, winding up the
+“The old chap, it seems, was in his own berth, winding up the
 chronometers, when the shock sent him spinning. Immediately it occurred
-to him--as he said afterwards--that the ship had struck something, and
+to him—as he said afterwards—that the ship had struck something, and
 he ran out into the cabin. There, he saw, the cabin-table had vanished
 somewhere. The deck being blown up, it had fallen down into the
 lazarette of course. Where we had our breakfast that morning he saw only
 a great hole in the floor. This appeared to him so awfully mysterious,
 and impressed him so immensely, that what he saw and heard after he got
 on deck were mere trifles in comparison. And, mark, he noticed directly
-the wheel deserted and his barque off her course--and his only thought
+the wheel deserted and his barque off her course—and his only thought
 was to get that miserable, stripped, undecked, smouldering shell of
 a ship back again with her head pointing at her port of destination.
-Bankok! That's what he was after. I tell you this quiet, bowed,
+Bankok! That’s what he was after. I tell you this quiet, bowed,
 bandy-legged, almost deformed little man was immense in the singleness
 of his idea and in his placid ignorance of our agitation. He motioned us
 forward with a commanding gesture, and went to take the wheel himself.
 
-"Yes; that was the first thing we did--trim the yards of that wreck! No
+“Yes; that was the first thing we did—trim the yards of that wreck! No
 one was killed, or even disabled, but everyone was more or less hurt.
 You should have seen them! Some were in rags, with black faces, like
 coal-heavers, like sweeps, and had bullet heads that seemed closely
@@ -706,8 +706,8 @@ cropped, but were in fact singed to the skin. Others, of the watch
 below, awakened by being shot out from their collapsing bunks, shivered
 incessantly, and kept on groaning even as we went about our work. But
 they all worked. That crew of Liverpool hard cases had in them the right
-stuff. It's my experience they always have. It is the sea that gives
-it--the vastness, the loneliness surrounding their dark stolid souls.
+stuff. It’s my experience they always have. It is the sea that gives
+it—the vastness, the loneliness surrounding their dark stolid souls.
 Ah! Well! we stumbled, we crept, we fell, we barked our shins on the
 wreckage, we hauled. The masts stood, but we did not know how much they
 might be charred down below. It was nearly calm, but a long swell ran
@@ -715,11 +715,11 @@ from the west and made her roll. They might go at any moment. We looked
 at them with apprehension. One could not foresee which way they would
 fall.
 
-"Then we retreated aft and looked about us. The deck was a tangle of
+“Then we retreated aft and looked about us. The deck was a tangle of
 planks on edge, of planks on end, of splinters, of ruined woodwork. The
 masts rose from that chaos like big trees above a matted undergrowth.
 The interstices of that mass of wreckage were full of something whitish,
-sluggish, stirring--of something that was like a greasy fog. The
+sluggish, stirring—of something that was like a greasy fog. The
 smoke of the invisible fire was coming up again, was trailing, like a
 poisonous thick mist in some valley choked with dead wood. Already lazy
 wisps were beginning to curl upwards amongst the mass of splinters. Here
@@ -728,11 +728,11 @@ fife-rail had been shot through the foresail, and the sky made a patch
 of glorious blue in the ignobly soiled canvas. A portion of several
 boards holding together had fallen across the rail, and one end
 protruded overboard, like a gangway leading upon nothing, like a gangway
-leading over the deep sea, leading to death--as if inviting us to walk
+leading over the deep sea, leading to death—as if inviting us to walk
 the plank at once and be done with our ridiculous troubles. And still
-the air, the sky--a ghost, something invisible was hailing the ship.
+the air, the sky—a ghost, something invisible was hailing the ship.
 
-"Someone had the sense to look over, and there was the helmsman, who had
+“Someone had the sense to look over, and there was the helmsman, who had
 impulsively jumped overboard, anxious to come back. He yelled and swam
 lustily like a merman, keeping up with the ship. We threw him a
 rope, and presently he stood amongst us streaming with water and very
@@ -741,86 +741,86 @@ rail and chin in hand, gazed at the sea wistfully. We asked ourselves,
 What next? I thought, Now, this is something like. This is great. I
 wonder what will happen. O youth!
 
-"Suddenly Mahon sighted a steamer far astern. Captain Beard said, 'We
-may do something with her yet.' We hoisted two flags, which said in the
-international language of the sea, 'On fire. Want immediate assistance.'
+“Suddenly Mahon sighted a steamer far astern. Captain Beard said, ‘We
+may do something with her yet.’ We hoisted two flags, which said in the
+international language of the sea, ‘On fire. Want immediate assistance.’
 The steamer grew bigger rapidly, and by-and-by spoke with two flags on
-her foremast, 'I am coming to your assistance.'
+her foremast, ‘I am coming to your assistance.’
 
-"In half an hour she was abreast, to windward, within hail, and rolling
+“In half an hour she was abreast, to windward, within hail, and rolling
 slightly, with her engines stopped. We lost our composure, and yelled
-all together with excitement, 'We've been blown up.' A man in a white
-helmet, on the bridge, cried, 'Yes! All right! all right!' and he nodded
+all together with excitement, ‘We’ve been blown up.’ A man in a white
+helmet, on the bridge, cried, ‘Yes! All right! all right!’ and he nodded
 his head, and smiled, and made soothing motions with his hand as though
 at a lot of frightened children. One of the boats dropped in the water,
 and walked towards us upon the sea with her long oars. Four Calashes
-pulled a swinging stroke. This was my first sight of Malay seamen. I've
+pulled a swinging stroke. This was my first sight of Malay seamen. I’ve
 known them since, but what struck me then was their unconcern: they
 came alongside, and even the bowman standing up and holding to our
 main-chains with the boat-hook did not deign to lift his head for a
 glance. I thought people who had been blown up deserved more attention.
 
-"A little man, dry like a chip and agile like a monkey, clambered up. It
-was the mate of the steamer. He gave one look, and cried, 'O boys--you
-had better quit.'
+“A little man, dry like a chip and agile like a monkey, clambered up. It
+was the mate of the steamer. He gave one look, and cried, ‘O boys—you
+had better quit.’
 
-"We were silent. He talked apart with the captain for a time,--seemed to
+“We were silent. He talked apart with the captain for a time,—seemed to
 argue with him. Then they went away together to the steamer.
 
-"When our skipper came back we learned that the steamer was the
+“When our skipper came back we learned that the steamer was the
 _Sommerville_, Captain Nash, from West Australia to Singapore via
 Batavia with mails, and that the agreement was she should tow us to
 Anjer or Batavia, if possible, where we could extinguish the fire by
-scuttling, and then proceed on our voyage--to Bankok! The old man seemed
-excited. 'We will do it yet,' he said to Mahon, fiercely. He shook his
+scuttling, and then proceed on our voyage—to Bankok! The old man seemed
+excited. ‘We will do it yet,’ he said to Mahon, fiercely. He shook his
 fist at the sky. Nobody else said a word.
 
-"At noon the steamer began to tow. She went ahead slim and high, and
+“At noon the steamer began to tow. She went ahead slim and high, and
 what was left of the _Judea_ followed at the end of seventy fathom of
-tow-rope,--followed her swiftly like a cloud of smoke with mastheads
+tow-rope,—followed her swiftly like a cloud of smoke with mastheads
 protruding above. We went aloft to furl the sails. We coughed on the
 yards, and were careful about the bunts. Do you see the lot of us there,
 putting a neat furl on the sails of that ship doomed to arrive nowhere?
-There was not a man who didn't think that at any moment the masts would
+There was not a man who didn’t think that at any moment the masts would
 topple over. From aloft we could not see the ship for smoke, and
-they worked carefully, passing the gaskets with even turns. 'Harbour
-furl--aloft there!' cried Mahon from below.
+they worked carefully, passing the gaskets with even turns. ‘Harbour
+furl—aloft there!’ cried Mahon from below.
 
-"You understand this? I don't think one of those chaps expected to get
+“You understand this? I don’t think one of those chaps expected to get
 down in the usual way. When we did I heard them saying to each other,
-'Well, I thought we would come down overboard, in a lump--sticks and
-all--blame me if I didn't.' 'That's what I was thinking to myself,'
+‘Well, I thought we would come down overboard, in a lump—sticks and
+all—blame me if I didn’t.’ ‘That’s what I was thinking to myself,’
 would answer wearily another battered and bandaged scarecrow. And, mind,
 these were men without the drilled-in habit of obedience. To an onlooker
 they would be a lot of profane scallywags without a redeeming
-point. What made them do it--what made them obey me when I, thinking
+point. What made them do it—what made them obey me when I, thinking
 consciously how fine it was, made them drop the bunt of the foresail
 twice to try and do it better? What? They had no professional
-reputation--no examples, no praise. It wasn't a sense of duty; they all
-knew well enough how to shirk, and laze, and dodge--when they had a mind
-to it--and mostly they had. Was it the two pounds ten a month that sent
-them there? They didn't think their pay half good enough. No; it was
-something in them, something inborn and subtle and everlasting. I don't
-say positively that the crew of a French or German merchantman wouldn't
+reputation—no examples, no praise. It wasn’t a sense of duty; they all
+knew well enough how to shirk, and laze, and dodge—when they had a mind
+to it—and mostly they had. Was it the two pounds ten a month that sent
+them there? They didn’t think their pay half good enough. No; it was
+something in them, something inborn and subtle and everlasting. I don’t
+say positively that the crew of a French or German merchantman wouldn’t
 have done it, but I doubt whether it would have been done in the same
 way. There was a completeness in it, something solid like a principle,
-and masterful like an instinct--a disclosure of something secret--of
+and masterful like an instinct—a disclosure of something secret—of
 that hidden something, that gift, of good or evil that makes racial
 difference, that shapes the fate of nations.
 
-"It was that night at ten that, for the first time since we had been
+“It was that night at ten that, for the first time since we had been
 fighting it, we saw the fire. The speed of the towing had fanned the
 smoldering destruction. A blue gleam appeared forward, shining below the
 wreck of the deck. It wavered in patches, it seemed to stir and creep
-like the light of a glowworm. I saw it first, and told Mahon. 'Then the
-game's up,' he said. 'We had better stop this towing, or she will burst
-out suddenly fore and aft before we can clear out.' We set up a yell;
+like the light of a glowworm. I saw it first, and told Mahon. ‘Then the
+game’s up,’ he said. ‘We had better stop this towing, or she will burst
+out suddenly fore and aft before we can clear out.’ We set up a yell;
 rang bells to attract their attention; they towed on. At last Mahon and
 I had to crawl forward and cut the rope with an ax. There was no time to
 cast off the lashings. Red tongues could be seen licking the wilderness
 of splinters under our feet as we made our way back to the poop.
 
-"Of course they very soon found out in the steamer that the rope
+“Of course they very soon found out in the steamer that the rope
 was gone. She gave a loud blast of her whistle, her lights were seen
 sweeping in a wide circle, she came up ranging close alongside, and
 stopped. We were all in a tight group on the poop looking at her. Every
@@ -829,18 +829,18 @@ a twisted top shot up forward and threw upon the black sea a circle
 of light, with the two vessels side by side and heaving gently in its
 center. Captain Beard had been sitting on the gratings still and mute
 for hours, but now he rose slowly and advanced in front of us, to the
-mizzen-shrouds. Captain Nash hailed: 'Come along! Look sharp. I have
-mail-bags on board. I will take you and your boats to Singapore.'
+mizzen-shrouds. Captain Nash hailed: ‘Come along! Look sharp. I have
+mail-bags on board. I will take you and your boats to Singapore.’
 
-"'Thank you! No!' said our skipper. 'We must see the last of the ship.'
+“‘Thank you! No!’ said our skipper. ‘We must see the last of the ship.’
 
-"'I can't stand by any longer,' shouted the other. 'Mails--you know.'
+“‘I can’t stand by any longer,’ shouted the other. ‘Mails—you know.’
 
-"'Ay! ay! We are all right.'
+“‘Ay! ay! We are all right.’
 
-"'Very well! I'll report you in Singapore.... Good-bye!'
+“‘Very well! I’ll report you in Singapore.... Good-bye!’
 
-"He waved his hand. Our men dropped their bundles quietly. The steamer
+“He waved his hand. Our men dropped their bundles quietly. The steamer
 moved ahead, and passing out of the circle of light, vanished at once
 from our sight, dazzled by the fire which burned fiercely. And then I
 knew that I would see the East first as commander of a small boat. I
@@ -848,15 +848,15 @@ thought it fine; and the fidelity to the old ship was fine. We should
 see the last of her. Oh the glamour of youth! Oh the fire of it, more
 dazzling than the flames of the burning ship, throwing a magic light on
 the wide earth, leaping audaciously to the sky, presently to be quenched
-by time, more cruel, more pitiless, more bitter than the sea--and like
-the flames of the burning ship surrounded by an impenetrable night."
+by time, more cruel, more pitiless, more bitter than the sea—and like
+the flames of the burning ship surrounded by an impenetrable night.”
 
 *****
 
-"The old man warned us in his gentle and inflexible way that it was part
+“The old man warned us in his gentle and inflexible way that it was part
 of our duty to save for the under-writers as much as we could of the
-ship's gear. According we went to work aft, while she blazed forward to
-give us plenty of light. We lugged out a lot of rubbish. What didn't we
+ship’s gear. According we went to work aft, while she blazed forward to
+give us plenty of light. We lugged out a lot of rubbish. What didn’t we
 save? An old barometer fixed with an absurd quantity of screws nearly
 cost me my life: a sudden rush of smoke came upon me, and I just got
 away in time. There were various stores, bolts of canvas, coils of rope;
@@ -865,13 +865,13 @@ gunwales. One would have thought the old man wanted to take as much as
 he could of his first command with him. He was very very quiet, but off
 his balance evidently. Would you believe it? He wanted to take a length
 of old stream-cable and a kedge-anchor with him in the long-boat. We
-said, 'Ay, ay, sir,' deferentially, and on the quiet let the thing slip
+said, ‘Ay, ay, sir,’ deferentially, and on the quiet let the thing slip
 overboard. The heavy medicine-chest went that way, two bags of green
-coffee, tins of paint--fancy, paint!--a whole lot of things. Then I was
+coffee, tins of paint—fancy, paint!—a whole lot of things. Then I was
 ordered with two hands into the boats to make a stowage and get them
 ready against the time it would be proper for us to leave the ship.
 
-"We put everything straight, stepped the long-boat's mast for our
+“We put everything straight, stepped the long-boat’s mast for our
 skipper, who was in charge of her, and I was not sorry to sit down for a
 moment. My face felt raw, every limb ached as if broken, I was aware
 of all my ribs, and would have sworn to a twist in the back-bone. The
@@ -882,8 +882,8 @@ with rumbles as of thunder. There were cracks, detonations, and from
 the cone of flame the sparks flew upwards, as man is born to trouble, to
 leaky ships, and to ships that burn.
 
-"What bothered me was that the ship, lying broadside to the swell and to
-such wind as there was--a mere breath--the boats would not keep astern
+“What bothered me was that the ship, lying broadside to the swell and to
+such wind as there was—a mere breath—the boats would not keep astern
 where they were safe, but persisted, in a pig-headed way boats have,
 in getting under the counter and then swinging alongside. They were
 knocking about dangerously and coming near the flame, while the ship
@@ -897,12 +897,12 @@ not only my share of the work, but also had to keep at it two men who
 showed a constant inclination to lay themselves down and let things
 slide.
 
-"At last I hailed 'On deck there,' and someone looked over. 'We're ready
-here,' I said. The head disappeared, and very soon popped up again. 'The
+“At last I hailed ‘On deck there,’ and someone looked over. ‘We’re ready
+here,’ I said. The head disappeared, and very soon popped up again. ‘The
 captain says, All right, sir, and to keep the boats well clear of the
-ship.'
+ship.’
 
-"Half an hour passed. Suddenly there was a frightful racket, rattle,
+“Half an hour passed. Suddenly there was a frightful racket, rattle,
 clanking of chain, hiss of water, and millions of sparks flew up into
 the shivering column of smoke that stood leaning slightly above the
 ship. The cat-heads had burned away, and the two red-hot anchors had
@@ -910,17 +910,17 @@ gone to the bottom, tearing out after them two hundred fathom of red-hot
 chain. The ship trembled, the mass of flame swayed as if ready to
 collapse, and the fore top-gallant-mast fell. It darted down like
 an arrow of fire, shot under, and instantly leaping up within an
-oar's-length of the boats, floated quietly, very black on the luminous
+oar’s-length of the boats, floated quietly, very black on the luminous
 sea. I hailed the deck again. After some time a man in an unexpectedly
 cheerful but also muffled tone, as though he had been trying to speak
-with his mouth shut, informed me, 'Coming directly, sir,' and vanished.
+with his mouth shut, informed me, ‘Coming directly, sir,’ and vanished.
 For a long time I heard nothing but the whir and roar of the fire. There
 were also whistling sounds. The boats jumped, tugged at the painters,
 ran at each other playfully, knocked their sides together, or, do what
-we would, swung in a bunch against the ship's side. I couldn't stand it
+we would, swung in a bunch against the ship’s side. I couldn’t stand it
 any longer, and swarming up a rope, clambered aboard over the stern.
 
-"It was as bright as day. Coming up like this, the sheet of fire facing
+“It was as bright as day. Coming up like this, the sheet of fire facing
 me, was a terrifying sight, and the heat seemed hardly bearable at
 first. On a settee cushion dragged out of the cabin, Captain Beard,
 with his legs drawn up and one arm under his head, slept with the light
@@ -928,66 +928,66 @@ playing on him. Do you know what the rest were busy about? They were
 sitting on deck right aft, round an open case, eating bread and cheese
 and drinking bottled stout.
 
-"On the background of flames twisting in fierce tongues above their
+“On the background of flames twisting in fierce tongues above their
 heads they seemed at home like salamanders, and looked like a band
 of desperate pirates. The fire sparkled in the whites of their eyes,
 gleamed on patches of white skin seen through the torn shirts. Each
-had the marks as of a battle about him--bandaged heads, tied-up arms, a
-strip of dirty rag round a knee--and each man had a bottle between his
+had the marks as of a battle about him—bandaged heads, tied-up arms, a
+strip of dirty rag round a knee—and each man had a bottle between his
 legs and a chunk of cheese in his hand. Mahon got up. With his handsome
 and disreputable head, his hooked profile, his long white beard, and
 with an uncorked bottle in his hand, he resembled one of those reckless
-sea-robbers of old making merry amidst violence and disaster. 'The last
-meal on board,' he explained solemnly. 'We had nothing to eat all
-day, and it was no use leaving all this.' He flourished the bottle and
-indicated the sleeping skipper. 'He said he couldn't swallow anything,
-so I got him to lie down,' he went on; and as I stared, 'I don't know
+sea-robbers of old making merry amidst violence and disaster. ‘The last
+meal on board,’ he explained solemnly. ‘We had nothing to eat all
+day, and it was no use leaving all this.’ He flourished the bottle and
+indicated the sleeping skipper. ‘He said he couldn’t swallow anything,
+so I got him to lie down,’ he went on; and as I stared, ‘I don’t know
 whether you are aware, young fellow, the man had no sleep to speak of
-for days--and there will be dam' little sleep in the boats.' 'There
-will be no boats by-and-by if you fool about much longer,' I said,
+for days—and there will be dam’ little sleep in the boats.’ ‘There
+will be no boats by-and-by if you fool about much longer,’ I said,
 indignantly. I walked up to the skipper and shook him by the shoulder.
-At last he opened his eyes, but did not move. 'Time to leave her, sir,'
+At last he opened his eyes, but did not move. ‘Time to leave her, sir,’
 I said, quietly.
 
-"He got up painfully, looked at the flames, at the sea sparkling round
+“He got up painfully, looked at the flames, at the sea sparkling round
 the ship, and black, black as ink farther away; he looked at the stars
 shining dim through a thin veil of smoke in a sky black, black as
 Erebus.
 
-"'Youngest first,' he said.
+“‘Youngest first,’ he said.
 
-"And the ordinary seaman, wiping his mouth with the back of his hand,
+“And the ordinary seaman, wiping his mouth with the back of his hand,
 got up, clambered over the taffrail, and vanished. Others followed. One,
 on the point of going over, stopped short to drain his bottle, and with
-a great swing of his arm flung it at the fire. 'Take this!' he cried.
+a great swing of his arm flung it at the fire. ‘Take this!’ he cried.
 
-"The skipper lingered disconsolately, and we left him to commune alone
+“The skipper lingered disconsolately, and we left him to commune alone
 for awhile with his first command. Then I went up again and brought
 him away at last. It was time. The ironwork on the poop was hot to the
 touch.
 
-"Then the painter of the long-boat was cut, and the three boats, tied
+“Then the painter of the long-boat was cut, and the three boats, tied
 together, drifted clear of the ship. It was just sixteen hours after the
 explosion when we abandoned her. Mahon had charge of the second boat,
-and I had the smallest--the 14-foot thing. The long-boat would have
+and I had the smallest—the 14-foot thing. The long-boat would have
 taken the lot of us; but the skipper said we must save as much property
-as we could--for the under-writers--and so I got my first command. I had
+as we could—for the under-writers—and so I got my first command. I had
 two men with me, a bag of biscuits, a few tins of meat, and a breaker of
 water. I was ordered to keep close to the long-boat, that in case of bad
 weather we might be taken into her.
 
-"And do you know what I thought? I thought I would part company as soon
-as I could. I wanted to have my first command all to myself. I wasn't
+“And do you know what I thought? I thought I would part company as soon
+as I could. I wanted to have my first command all to myself. I wasn’t
 going to sail in a squadron if there were a chance for independent
 cruising. I would make land by myself. I would beat the other boats.
 Youth! All youth! The silly, charming, beautiful youth.
 
-"But we did not make a start at once. We must see the last of the ship.
+“But we did not make a start at once. We must see the last of the ship.
 And so the boats drifted about that night, heaving and setting on the
 swell. The men dozed, waked, sighed, groaned. I looked at the burning
 ship.
 
-"Between the darkness of earth and heaven she was burning fiercely upon
+“Between the darkness of earth and heaven she was burning fiercely upon
 a disc of purple sea shot by the blood-red play of gleams; upon a disc
 of water glittering and sinister. A high, clear flame, an immense and
 lonely flame, ascended from the ocean, and from its summit the black
@@ -1003,8 +1003,8 @@ and watchful, the vast night lying silent upon the sea. At daylight
 she was only a charred shell, floating still under a cloud of smoke and
 bearing a glowing mass of coal within.
 
-"Then the oars were got out, and the boats forming in a line moved round
-her remains as if in procession--the long-boat leading. As we pulled
+“Then the oars were got out, and the boats forming in a line moved round
+her remains as if in procession—the long-boat leading. As we pulled
 across her stern a slim dart of fire shot out viciously at us, and
 suddenly she went down, head first, in a great hiss of steam. The
 unconsumed stern was the last to sink; but the paint had gone, had
@@ -1012,31 +1012,31 @@ cracked, had peeled off, and there were no letters, there was no word,
 no stubborn device that was like her soul, to flash at the rising sun
 her creed and her name.
 
-"We made our way north. A breeze sprang up, and about noon all the boats
+“We made our way north. A breeze sprang up, and about noon all the boats
 came together for the last time. I had no mast or sail in mine, but I
 made a mast out of a spare oar and hoisted a boat-awning for a sail,
 with a boat-hook for a yard. She was certainly over-masted, but I had
 the satisfaction of knowing that with the wind aft I could beat the
 other two. I had to wait for them. Then we all had a look at the
-captain's chart, and, after a sociable meal of hard bread and water, got
+captain’s chart, and, after a sociable meal of hard bread and water, got
 our last instructions. These were simple: steer north, and keep together
-as much as possible. 'Be careful with that jury rig, Marlow,' said the
+as much as possible. ‘Be careful with that jury rig, Marlow,’ said the
 captain; and Mahon, as I sailed proudly past his boat, wrinkled his
-curved nose and hailed, 'You will sail that ship of yours under water,
-if you don't look out, young fellow.' He was a malicious old man--and
+curved nose and hailed, ‘You will sail that ship of yours under water,
+if you don’t look out, young fellow.’ He was a malicious old man—and
 may the deep sea where he sleeps now rock him gently, rock him tenderly
 to the end of time!
 
-"Before sunset a thick rain-squall passed over the two boats, which were
+“Before sunset a thick rain-squall passed over the two boats, which were
 far astern, and that was the last I saw of them for a time. Next day I
-sat steering my cockle-shell--my first command--with nothing but water
+sat steering my cockle-shell—my first command—with nothing but water
 and sky around me. I did sight in the afternoon the upper sails of a
 ship far away, but said nothing, and my men did not notice her. You see
 I was afraid she might be homeward bound, and I had no mind to turn back
-from the portals of the East. I was steering for Java--another blessed
-name--like Bankok, you know. I steered many days.
+from the portals of the East. I was steering for Java—another blessed
+name—like Bankok, you know. I steered many days.
 
-"I need not tell you what it is to be knocking about in an open boat. I
+“I need not tell you what it is to be knocking about in an open boat. I
 remember nights and days of calm when we pulled, we pulled, and the
 boat seemed to stand still, as if bewitched within the circle of the sea
 horizon. I remember the heat, the deluge of rain-squalls that kept us
@@ -1045,14 +1045,14 @@ hours on end with a mouth dry as a cinder and a steering-oar over the
 stern to keep my first command head on to a breaking sea. I did not know
 how good a man I was till then. I remember the drawn faces, the dejected
 figures of my two men, and I remember my youth and the feeling that
-will never come back any more--the feeling that I could last for ever,
+will never come back any more—the feeling that I could last for ever,
 outlast the sea, the earth, and all men; the deceitful feeling that
-lures us on to joys, to perils, to love, to vain effort--to death; the
+lures us on to joys, to perils, to love, to vain effort—to death; the
 triumphant conviction of strength, the heat of life in the handful of
 dust, the glow in the heart that with every year grows dim, grows cold,
-grows small, and expires--and expires, too soon--before life itself.
+grows small, and expires—and expires, too soon—before life itself.
 
-"And this is how I see the East. I have seen its secret places and have
+“And this is how I see the East. I have seen its secret places and have
 looked into its very soul; but now I see it always from a small boat, a
 high outline of mountains, blue and afar in the morning; like faint mist
 at noon; a jagged wall of purple at sunset. I have the feel of the oar
@@ -1061,117 +1061,117 @@ bay, a wide bay, smooth as glass and polished like ice, shimmering in
 the dark. A red light burns far off upon the gloom of the land, and
 the night is soft and warm. We drag at the oars with aching arms, and
 suddenly a puff of wind, a puff faint and tepid and laden with strange
-odors of blossoms, of aromatic wood, comes out of the still night--the
+odors of blossoms, of aromatic wood, comes out of the still night—the
 first sigh of the East on my face. That I can never forget. It was
 impalpable and enslaving, like a charm, like a whispered promise of
 mysterious delight.
 
-"We had been pulling this finishing spell for eleven hours. Two pulled,
+“We had been pulling this finishing spell for eleven hours. Two pulled,
 and he whose turn it was to rest sat at the tiller. We had made out the
 red light in that bay and steered for it, guessing it must mark some
 small coasting port. We passed two vessels, outlandish and high-sterned,
 sleeping at anchor, and, approaching the light, now very dim, ran the
-boat's nose against the end of a jutting wharf. We were blind with
+boat’s nose against the end of a jutting wharf. We were blind with
 fatigue. My men dropped the oars and fell off the thwarts as if dead. I
 made fast to a pile. A current rippled softly. The scented obscurity of
 the shore was grouped into vast masses, a density of colossal clumps of
-vegetation, probably--mute and fantastic shapes. And at their foot the
+vegetation, probably—mute and fantastic shapes. And at their foot the
 semicircle of a beach gleamed faintly, like an illusion. There was not
 a light, not a stir, not a sound. The mysterious East faced me, perfumed
 like a flower, silent like death, dark like a grave.
 
-"And I sat weary beyond expression, exulting like a conqueror, sleepless
+“And I sat weary beyond expression, exulting like a conqueror, sleepless
 and entranced as if before a profound, a fateful enigma.
 
-"A splashing of oars, a measured dip reverberating on the level of
+“A splashing of oars, a measured dip reverberating on the level of
 water, intensified by the silence of the shore into loud claps, made me
 jump up. A boat, a European boat, was coming in. I invoked the name of
 the dead; I hailed: _Judea_ ahoy! A thin shout answered.
 
-"It was the captain. I had beaten the flagship by three hours, and I
-was glad to hear the old man's voice, tremulous and tired. 'Is it you,
-Marlow?' 'Mind the end of that jetty, sir,' I cried.
+“It was the captain. I had beaten the flagship by three hours, and I
+was glad to hear the old man’s voice, tremulous and tired. ‘Is it you,
+Marlow?’ ‘Mind the end of that jetty, sir,’ I cried.
 
-"He approached cautiously, and brought up with the deep-sea lead-line
-which we had saved--for the under-writers. I eased my painter and fell
+“He approached cautiously, and brought up with the deep-sea lead-line
+which we had saved—for the under-writers. I eased my painter and fell
 alongside. He sat, a broken figure at the stern, wet with dew, his hands
-clasped in his lap. His men were asleep already. 'I had a terrible time
-of it,' he murmured. 'Mahon is behind--not very far.' We conversed
+clasped in his lap. His men were asleep already. ‘I had a terrible time
+of it,’ he murmured. ‘Mahon is behind—not very far.’ We conversed
 in whispers, in low whispers, as if afraid to wake up the land. Guns,
 thunder, earthquakes would not have awakened the men just then.
 
-"Looking around as we talked, I saw away at sea a bright light travelling
-in the night. 'There's a steamer passing the bay,' I said. She was not
-passing, she was entering, and she even came close and anchored. 'I
-wish,' said the old man, 'you would find out whether she is English.
-Perhaps they could give us a passage somewhere.' He seemed nervously
+“Looking around as we talked, I saw away at sea a bright light travelling
+in the night. ‘There’s a steamer passing the bay,’ I said. She was not
+passing, she was entering, and she even came close and anchored. ‘I
+wish,’ said the old man, ‘you would find out whether she is English.
+Perhaps they could give us a passage somewhere.’ He seemed nervously
 anxious. So by dint of punching and kicking I started one of my men into
 a state of somnambulism, and giving him an oar, took another and pulled
 towards the lights of the steamer.
 
-"There was a murmur of voices in her, metallic hollow clangs of the
+“There was a murmur of voices in her, metallic hollow clangs of the
 engine-room, footsteps on the deck. Her ports shone, round like dilated
 eyes. Shapes moved about, and there was a shadowy man high up on the
 bridge. He heard my oars.
 
-"And then, before I could open my lips, the East spoke to me, but it was
+“And then, before I could open my lips, the East spoke to me, but it was
 in a Western voice. A torrent of words was poured into the enigmatical,
 the fateful silence; outlandish, angry words, mixed with words and even
 whole sentences of good English, less strange but even more surprising.
 The voice swore and cursed violently; it riddled the solemn peace of the
 bay by a volley of abuse. It began by calling me Pig, and from that went
-crescendo into unmentionable adjectives--in English. The man up there
+crescendo into unmentionable adjectives—in English. The man up there
 raged aloud in two languages, and with a sincerity in his fury that
 almost convinced me I had, in some way, sinned against the harmony of
 the universe. I could hardly see him, but began to think he would work
 himself into a fit.
 
-"Suddenly he ceased, and I could hear him snorting and blowing like a
-porpoise. I said--
+“Suddenly he ceased, and I could hear him snorting and blowing like a
+porpoise. I said—
 
-"'What steamer is this, pray?'
+“‘What steamer is this, pray?’
 
-"'Eh? What's this? And who are you?'
+“‘Eh? What’s this? And who are you?’
 
-"'Castaway crew of an English barque burnt at sea. We came here
+“‘Castaway crew of an English barque burnt at sea. We came here
 to-night. I am the second mate. The captain is in the long-boat, and
-wishes to know if you would give us a passage somewhere.'
+wishes to know if you would give us a passage somewhere.’
 
-"'Oh, my goodness! I say... This is the Celestial from Singapore on
-her return trip. I'll arrange with your captain in the morning...
-and,... I say... did you hear me just now?'
+“‘Oh, my goodness! I say... This is the Celestial from Singapore on
+her return trip. I’ll arrange with your captain in the morning...
+and,... I say... did you hear me just now?’
 
-"'I should think the whole bay heard you.'
+“‘I should think the whole bay heard you.’
 
-"'I thought you were a shore-boat. Now, look here--this infernal lazy
-scoundrel of a caretaker has gone to sleep again--curse him. The light
+“‘I thought you were a shore-boat. Now, look here—this infernal lazy
+scoundrel of a caretaker has gone to sleep again—curse him. The light
 is out, and I nearly ran foul of the end of this damned jetty. This is
 the third time he plays me this trick. Now, I ask you, can anybody stand
-this kind of thing? It's enough to drive a man out of his mind. I'll
-report him.... I'll get the Assistant Resident to give him the
-sack, by... See--there's no light. It's out, isn't it? I take you to
-witness the light's out. There should be a light, you know. A red light
-on the--'
+this kind of thing? It’s enough to drive a man out of his mind. I’ll
+report him.... I’ll get the Assistant Resident to give him the
+sack, by... See—there’s no light. It’s out, isn’t it? I take you to
+witness the light’s out. There should be a light, you know. A red light
+on the—’
 
-"'There was a light,' I said, mildly.
+“‘There was a light,’ I said, mildly.
 
-"'But it's out, man! What's the use of talking like this? You can see
-for yourself it's out--don't you? If you had to take a valuable steamer
-along this God-forsaken coast you would want a light too. I'll kick him
-from end to end of his miserable wharf. You'll see if I don't. I will--'
+“‘But it’s out, man! What’s the use of talking like this? You can see
+for yourself it’s out—don’t you? If you had to take a valuable steamer
+along this God-forsaken coast you would want a light too. I’ll kick him
+from end to end of his miserable wharf. You’ll see if I don’t. I will—’
 
-"'So I may tell my captain you'll take us?' I broke in.
+“‘So I may tell my captain you’ll take us?’ I broke in.
 
-"'Yes, I'll take you. Good night,' he said, brusquely.
+“‘Yes, I’ll take you. Good night,’ he said, brusquely.
 
-"I pulled back, made fast again to the jetty, and then went to sleep
+“I pulled back, made fast again to the jetty, and then went to sleep
 at last. I had faced the silence of the East. I had heard some of its
 languages. But when I opened my eyes again the silence was as complete
 as though it had never been broken. I was lying in a flood of light, and
 the sky had never looked so far, so high, before. I opened my eyes and
 lay without moving.
 
-"And then I saw the men of the East--they were looking at me. The whole
+“And then I saw the men of the East—they were looking at me. The whole
 length of the jetty was full of people. I saw brown, bronze, yellow
 faces, the black eyes, the glitter, the colour of an Eastern crowd.
 And all these beings stared without a murmur, without a sigh, without
@@ -1185,10 +1185,10 @@ mysterious, resplendent and somber, living and unchanged, full of
 danger and promise. And these were the men. I sat up suddenly. A wave
 of movement passed through the crowd from end to end, passed along
 the heads, swayed the bodies, ran along the jetty like a ripple on the
-water, like a breath of wind on a field--and all was still again. I see
-it now--the wide sweep of the bay, the glittering sands, the wealth of
+water, like a breath of wind on a field—and all was still again. I see
+it now—the wide sweep of the bay, the glittering sands, the wealth of
 green infinite and varied, the sea blue like the sea of a dream,
-the crowd of attentive faces, the blaze of vivid colour--the water
+the crowd of attentive faces, the blaze of vivid colour—the water
 reflecting it all, the curve of the shore, the jetty, the high-sterned
 outlandish craft floating still, and the three boats with tired men
 from the West sleeping unconscious of the land and the people and of the
@@ -1196,47 +1196,47 @@ violence of sunshine. They slept thrown across the thwarts, curled on
 bottom-boards, in the careless attitudes of death. The head of the old
 skipper, leaning back in the stern of the long-boat, had fallen on his
 breast, and he looked as though he would never wake. Farther out old
-Mahon's face was upturned to the sky, with the long white beard spread
+Mahon’s face was upturned to the sky, with the long white beard spread
 out on his breast, as though he had been shot where he sat at the
 tiller; and a man, all in a heap in the bows of the boat, slept with
 both arms embracing the stem-head and with his cheek laid on the
 gunwale. The East looked at them without a sound.
 
-"I have known its fascination since: I have seen the mysterious shores,
+“I have known its fascination since: I have seen the mysterious shores,
 the still water, the lands of brown nations, where a stealthy Nemesis
 lies in wait, pursues, overtakes so many of the conquering race, who are
 proud of their wisdom, of their knowledge, of their strength. But for me
 all the East is contained in that vision of my youth. It is all in that
 moment when I opened my young eyes on it. I came upon it from a tussle
-with the sea--and I was young--and I saw it looking at me. And this is
+with the sea—and I was young—and I saw it looking at me. And this is
 all that is left of it! Only a moment; a moment of strength, of
-romance, of glamour--of youth!... A flick of sunshine upon a strange
+romance, of glamour—of youth!... A flick of sunshine upon a strange
 shore, the time to remember, the time for a sigh,
-and--good-bye!--Night--Good-bye...!"
+and—good-bye!—Night—Good-bye...!”
 
 He drank.
 
-"Ah! The good old time--the good old time. Youth and the sea. Glamour
+“Ah! The good old time—the good old time. Youth and the sea. Glamour
 and the sea! The good, strong sea, the salt, bitter sea, that could
-whisper to you and roar at you and knock your breath out of you."
+whisper to you and roar at you and knock your breath out of you.”
 
 He drank again.
 
-"By all that's wonderful, it is the sea, I believe, the sea itself--or
-is it youth alone? Who can tell? But you here--you all had something out
-of life: money, love--whatever one gets on shore--and, tell me, wasn't
+“By all that’s wonderful, it is the sea, I believe, the sea itself—or
+is it youth alone? Who can tell? But you here—you all had something out
+of life: money, love—whatever one gets on shore—and, tell me, wasn’t
 that the best time, that time when we were young at sea; young and
-had nothing, on the sea that gives nothing, except hard knocks--and
-sometimes a chance to feel your strength--that only--what you all
-regret?"
+had nothing, on the sea that gives nothing, except hard knocks—and
+sometimes a chance to feel your strength—that only—what you all
+regret?”
 
 And we all nodded at him: the man of finance, the man of accounts, the
 man of law, we all nodded at him over the polished table that like a
 still sheet of brown water reflected our faces, lined, wrinkled; our
 faces marked by toil, by deceptions, by success, by love; our weary eyes
 looking still, looking always, looking anxiously for something out of
-life, that while it is expected is already gone--has passed unseen, in
-a sigh, in a flash--together with the youth, with the strength, with the
+life, that while it is expected is already gone—has passed unseen, in
+a sigh, in a flash—together with the youth, with the strength, with the
 romance of illusions.
 
 
@@ -1253,7 +1253,7 @@ This and all associated files of various formats will be found in:
 
 Produced by Judith Boss and David Widger
 
-Updated editions will replace the previous one--the old editions
+Updated editions will replace the previous one—the old editions
 will be renamed.
 
 Creating the works from public domain print editions means that no
@@ -1268,7 +1268,7 @@ charge for the eBooks, unless you receive specific permission.  If you
 do not charge anything for copies of this eBook, complying with the
 rules is very easy.  You may use this eBook for nearly any purpose
 such as creation of derivative works, reports, performances and
-research.  They may be modified and printed and given away--you may do
+research.  They may be modified and printed and given away—you may do
 practically ANYTHING with public domain eBooks.  Redistribution is
 subject to the trademark license, especially commercial
 redistribution.
@@ -1282,8 +1282,8 @@ PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
 
 To protect the Project Gutenberg-tm mission of promoting the free
 distribution of electronic works, by using or distributing this work
-(or any other work associated in any way with the phrase "Project
-Gutenberg"), you agree to comply with all the terms of the Full Project
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
 Gutenberg-tm License (available with this file or online at
 http://gutenberg.org/license).
 
@@ -1302,7 +1302,7 @@ Gutenberg-tm electronic work and you do not agree to be bound by the
 terms of this agreement, you may obtain a refund from the person or
 entity to whom you paid the fee as set forth in paragraph 1.E.8.
 
-1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
 used on or associated in any way with an electronic work by people who
 agree to be bound by the terms of this agreement.  There are a few
 things that you can do with most Project Gutenberg-tm electronic works
@@ -1312,7 +1312,7 @@ Gutenberg-tm electronic works if you follow the terms of this agreement
 and help preserve free future access to Project Gutenberg-tm electronic
 works.  See paragraph 1.E below.
 
-1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
 or PGLAF), owns a compilation copyright in the collection of Project
 Gutenberg-tm electronic works.  Nearly all the individual works in the
 collection are in the public domain in the United States.  If an
@@ -1343,8 +1343,8 @@ States.
 1.E.1.  The following sentence, with active links to, or other immediate
 access to, the full Project Gutenberg-tm License must appear prominently
 whenever any copy of a Project Gutenberg-tm work (any work on which the
-phrase "Project Gutenberg" appears, or with which the phrase "Project
-Gutenberg" is associated) is accessed, displayed, performed, viewed,
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
 copied or distributed:
 
 This eBook is for the use of anyone anywhere at no cost and with
@@ -1357,7 +1357,7 @@ from the public domain (does not contain a notice indicating that it is
 posted with permission of the copyright holder), the work can be copied
 and distributed to anyone in the United States without paying any fees
 or charges.  If you are redistributing or providing access to a work
-with the phrase "Project Gutenberg" associated with or appearing on the
+with the phrase “Project Gutenberg” associated with or appearing on the
 work, you must comply either with the requirements of paragraphs 1.E.1
 through 1.E.7 or obtain permission for the use of the work and the
 Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
@@ -1384,11 +1384,11 @@ Gutenberg-tm License.
 compressed, marked up, nonproprietary or proprietary form, including any
 word processing or hypertext form.  However, if you provide access to or
 distribute copies of a Project Gutenberg-tm work in a format other than
-"Plain Vanilla ASCII" or other format used in the official version
+“Plain Vanilla ASCII” or other format used in the official version
 posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
 you must, at no additional cost, fee or expense to the user, provide a
 copy, a means of exporting a copy, or a means of obtaining a copy upon
-request, of the work in its original "Plain Vanilla ASCII" or other
+request, of the work in its original “Plain Vanilla ASCII” or other
 form.  Any alternate format must include the full Project Gutenberg-tm
 License as specified in paragraph 1.E.1.
 
@@ -1410,8 +1410,8 @@ that
      prepare (or are legally required to prepare) your periodic tax
      returns.  Royalty payments should be clearly marked as such and
      sent to the Project Gutenberg Literary Archive Foundation at the
-     address specified in Section 4, "Information about donations to
-     the Project Gutenberg Literary Archive Foundation."
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
 
 - You provide a full refund of any money paid by a user who notifies
      you in writing (or by e-mail) within 30 days of receipt that s/he
@@ -1443,14 +1443,14 @@ effort to identify, do copyright research on, transcribe and proofread
 public domain works in creating the Project Gutenberg-tm
 collection.  Despite these efforts, Project Gutenberg-tm electronic
 works, and the medium on which they may be stored, may contain
-"Defects," such as, but not limited to, incomplete, inaccurate or
+“Defects,” such as, but not limited to, incomplete, inaccurate or
 corrupt data, transcription errors, a copyright or other intellectual
 property infringement, a defective or damaged disk or other medium, a
 computer virus, or computer codes that damage or cannot be read by
 your equipment.
 
-1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
-of Replacement or Refund" described in paragraph 1.F.3, the Project
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES — Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
 Gutenberg Literary Archive Foundation, the owner of the Project
 Gutenberg-tm trademark, and any other party distributing a Project
 Gutenberg-tm electronic work under this agreement, disclaim all
@@ -1463,7 +1463,7 @@ LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
 INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
 DAMAGE.
 
-1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND — If you discover a
 defect in this electronic work within 90 days of receiving it, you can
 receive a refund of the money (if any) you paid for it by sending a
 written explanation to the person you received the work from.  If you
@@ -1477,7 +1477,7 @@ is also defective, you may demand a refund in writing without further
 opportunities to fix the problem.
 
 1.F.4.  Except for the limited right of replacement or refund set forth
-in paragraph 1.F.3, this work is provided to you 'AS-IS' WITH NO OTHER
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
 WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
 WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
 
@@ -1489,7 +1489,7 @@ interpreted to make the maximum disclaimer or limitation permitted by
 the applicable state law.  The invalidity or unenforceability of any
 provision of this agreement shall not void the remaining provisions.
 
-1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+1.F.6.  INDEMNITY — You agree to indemnify and hold the Foundation, the
 trademark owner, any agent or employee of the Foundation, anyone
 providing copies of Project Gutenberg-tm electronic works in accordance
 with this agreement, and any volunteers associated with the production,
@@ -1510,7 +1510,7 @@ because of the efforts of hundreds of volunteers and donations from
 people in all walks of life.
 
 Volunteers and financial support to provide volunteers with the
-assistance they need, are critical to reaching Project Gutenberg-tm's
+assistance they need, are critical to reaching Project Gutenberg-tm’s
 goals and ensuring that the Project Gutenberg-tm collection will
 remain freely available for generations to come.  In 2001, the Project
 Gutenberg Literary Archive Foundation was created to provide a secure
@@ -1526,18 +1526,18 @@ Foundation
 The Project Gutenberg Literary Archive Foundation is a non profit
 501(c)(3) educational corporation organized under the laws of the
 state of Mississippi and granted tax exempt status by the Internal
-Revenue Service.  The Foundation's EIN or federal tax identification
+Revenue Service.  The Foundation’s EIN or federal tax identification
 number is 64-6221541.  Its 501(c)(3) letter is posted at
 http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
 Literary Archive Foundation are tax deductible to the full extent
-permitted by U.S. federal laws and your state's laws.
+permitted by U.S. federal laws and your state’s laws.
 
-The Foundation's principal office is located at 4557 Melan Dr. S.
+The Foundation’s principal office is located at 4557 Melan Dr. S.
 Fairbanks, AK, 99712., but its volunteers and employees are scattered
 throughout numerous locations.  Its business office is located at
 809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
 business@pglaf.org.  Email contact links and up to date contact
-information can be found at the Foundation's web site and official
+information can be found at the Foundation’s web site and official
 page at http://pglaf.org
 
 For additional contact information:

--- a/525.txt
+++ b/525.txt
@@ -248,7 +248,7 @@ She lowered the window to say, ‘You are a good young man. If you see
 John—Captain Beard—without his muffler at night, just remind him from
 me to keep his throat well wrapped up.’ ‘Certainly, Mrs. Beard,’ I said.
 ‘You are a good young man; I noticed how attentive you are to John—to
-Captain—’ The train pulled out suddenly; I took my cap off to the old
+Captain——’ The train pulled out suddenly; I took my cap off to the old
 woman: I never saw her again... Pass the bottle.
 
 “We went to sea next day. When we made that start for Bankok we had been
@@ -1151,14 +1151,14 @@ this kind of thing? It’s enough to drive a man out of his mind. I’ll
 report him.... I’ll get the Assistant Resident to give him the
 sack, by... See—there’s no light. It’s out, isn’t it? I take you to
 witness the light’s out. There should be a light, you know. A red light
-on the—’
+on the——’
 
 “‘There was a light,’ I said, mildly.
 
 “‘But it’s out, man! What’s the use of talking like this? You can see
 for yourself it’s out—don’t you? If you had to take a valuable steamer
 along this God-forsaken coast you would want a light too. I’ll kick him
-from end to end of his miserable wharf. You’ll see if I don’t. I will—’
+from end to end of his miserable wharf. You’ll see if I don’t. I will——’
 
 “‘So I may tell my captain you’ll take us?’ I broke in.
 


### PR DESCRIPTION
Further additions to the punctuation-cleanup script. Conrad really tests this script :)

As expected, I have manually checked each one of the 425 changed lines.

Btw, the script now changes the character set declaration and declares this to be UTF-8 (since it ain't ASCII).
